### PR TITLE
fix: include styles.css in the package.json files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dist/index.js",
     "dist/index.es.js",
     "dist/index.umd.js",
-    "dist/index.d.ts"
+    "dist/index.d.ts",
+    "dist/styles.css"
   ],
   "targets": {
     "main": false,


### PR DESCRIPTION
This adds the `dist/styles.css` file to the `files` array in the library's `package.json`.

Closes #1 